### PR TITLE
Change instructions for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library helps with integrating Userlist into PHP applications.
 This library can be installed via [Composer](https://getcomposer.org):
 
 ```bash
-composer require userlistio/userlist
+composer require userlistio/userlist dev-master
 ```
 
 ## Configuration


### PR DESCRIPTION
Explicily specify `dev-master`, since no versions/releases have been tagged.

Or better yet, reject this PR and tag a release? 🙂 